### PR TITLE
Switch to new-style classes

### DIFF
--- a/release/bin/blender-thumbnailer.py
+++ b/release/bin/blender-thumbnailer.py
@@ -40,7 +40,7 @@ def open_wrapper_get():
     """ wrap OS specific read functionality here, fallback to 'open()'
     """
 
-    class GFileWrapper:
+    class GFileWrapper(object):
         __slots__ = ("mode", "g_file")
 
         def __init__(self, url, mode='r'):

--- a/release/scripts/modules/bl_app_override/helpers.py
+++ b/release/scripts/modules/bl_app_override/helpers.py
@@ -22,7 +22,7 @@
 # AppOverrideState
 
 
-class AppOverrideState:
+class AppOverrideState(object):
     """
     Utility class to encapsulate overriding the application state
     so that settings can be restored afterwards.

--- a/release/scripts/modules/bpy_restrict_state.py
+++ b/release/scripts/modules/bpy_restrict_state.py
@@ -29,7 +29,7 @@ __all__ = (
 import bpy as _bpy
 
 
-class _RestrictContext:
+class _RestrictContext(object):
     __slots__ = ()
     _real_data = _bpy.data
     # safe, the pointer never changes
@@ -44,7 +44,7 @@ class _RestrictContext:
         return self._real_pref
 
 
-class _RestrictData:
+class _RestrictData(object):
     __slots__ = ()
 
 
@@ -52,7 +52,7 @@ _context_restrict = _RestrictContext()
 _data_restrict = _RestrictData()
 
 
-class RestrictBlend:
+class RestrictBlend(object):
     __slots__ = ("context", "data")
 
     def __enter__(self):


### PR DESCRIPTION
We are using __slots__ in a number of places, indicating that we intended to use new-style classes.
See https://lgtm.com/rules/6770071/ for details. (These were found via lgtm.com, I happen to now work for Semmle who created that website.)