### PR TITLE
Nest CONCAT macro to fix a compile error

### DIFF
--- a/intern/cycles/util/util_defines.h
+++ b/intern/cycles/util/util_defines.h
@@ -145,6 +145,7 @@ template<typename T> static inline T decltype_helper(T x)
 #  define util_assert(statement)
 #endif
 
-#define CONCAT(a, ...) a##__VA_ARGS__
+#define CONCAT_HELPER(a, ...) a##__VA_ARGS__
+#define CONCAT(a, ...) CONCAT_HELPER(a, __VA_ARGS__)
 
 #endif /* __UTIL_DEFINES_H__ */


### PR DESCRIPTION
Using CONCAT with preprocessor tokens passed as parameters (for example CONCAT(make_, SPECTRAL_COLOR_DATA_TYPE(f)) ) would result in the parameters being concatenated without being expanded. 
By instead nesting the concatenation inside another macro, this ensures that the parameters get expanded before they are concatenated